### PR TITLE
fix: update recipe

### DIFF
--- a/chapter02/main.go
+++ b/chapter02/main.go
@@ -106,7 +106,7 @@ func UpdateRecipeHandler(c *gin.Context) {
 	index := -1
 	for i := 0; i < len(recipes); i++ {
 		if recipes[i].ID == id {
-			index = i 
+			index = i
 			break
 		}
 	}
@@ -116,6 +116,8 @@ func UpdateRecipeHandler(c *gin.Context) {
 		return
 	}
 
+    recipe.ID = recipes[index].ID
+    recipe.PublishedAt = recipes[index].PublishedAt
 	recipes[index] = recipe
 
 	c.JSON(http.StatusOK, recipe)


### PR DESCRIPTION
The ID and PublishedAt time are not retained when updating a recipe.

- Sets the ID of the new Recipe struct instance to the ID of the former.
- Sets the PublishedAt of the new Recipe struct instance to the PublishedAt of the former.

This pull request resolves the following issues:
- https://github.com/PacktPublishing/Building-Distributed-Applications-in-Gin/issues/8
- https://github.com/PacktPublishing/Building-Distributed-Applications-in-Gin/issues/13