### PR TITLE
hotfix: update recipe

### DIFF
--- a/chapter02/main.go
+++ b/chapter02/main.go
@@ -116,6 +116,9 @@ func UpdateRecipeHandler(c *gin.Context) {
 		return
 	}
 
+	recipe.ID = recipes[index].ID
+	recipe.PublishedAt = recipes[index].PublishedAt
+
 	recipes[index] = recipe
 
 	c.JSON(http.StatusOK, recipe)


### PR DESCRIPTION
The ID and PublishedAt time are not retained when updating a recipe.

- Sets the ID of the new Recipe struct instance to the ID of the former.
- Sets the PublishedAt of the new Recipe struct instance to the PublishedAt of the former.

This pull request resolves the following issues:
- https://github.com/PacktPublishing/Building-Distributed-Applications-in-Gin/issues/8
- https://github.com/PacktPublishing/Building-Distributed-Applications-in-Gin/issues/13